### PR TITLE
Use empty string to connect to default database

### DIFF
--- a/src/Checks/DatabaseHealthCheck.php
+++ b/src/Checks/DatabaseHealthCheck.php
@@ -22,6 +22,10 @@ class DatabaseHealthCheck extends HealthCheck
     {
         foreach (config('healthcheck.database.connections') as $connection) {
             try {
+                if ($connection == 'default') {
+                    $connection = '';
+                }
+
                 $pdo = $this->db->connection($connection)->getPdo();
             } catch (Exception $e) {
                 return $this->problem('Could not connect to db', [


### PR DESCRIPTION
Without this, Lumen attempts to connect to a database with the
connection name of "default", rather than the connection named in
DB_CONNECTION .env variable