### PR TITLE
Allow GitHub Actions to run on pull requests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,7 @@ name: Run tests
 
 on:
   push:
+  pull_request:
   schedule:
       - cron: '0 0 * * *'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - *
   pull_request:
   schedule:
       - cron: '0 0 * * *'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,10 @@ name: Run tests
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - *
   pull_request:
   schedule:
       - cron: '0 0 * * *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Run CI on pull requests
 
 ## [1.0.4] - 2020-04-26
 


### PR DESCRIPTION
This is just a quick tweak to allow our tests workflow to run on PRs as well as pushes to master and the cron.