### PR TITLE
Change assertEquals to assertSame.

### DIFF
--- a/tests/Checks/CrossServiceHealthCheckTest.php
+++ b/tests/Checks/CrossServiceHealthCheckTest.php
@@ -28,8 +28,8 @@ class CrossServiceHealthCheckTest extends TestCase
         $check = new CrossServiceHealthCheck($client, $request);
 
         $this->assertTrue($check->status()->isOkay());
-        $this->assertEquals(1, count($container));
-        $this->assertEquals('http://api.example.com/health', (string) $container[0]['request']->getUri());
+        $this->assertSame(1, count($container));
+        $this->assertSame('http://api.example.com/health', (string) $container[0]['request']->getUri());
         $this->assertTrue(isset($container[0]['request']->getHeaders()['X-Service-Check']));
     }
 
@@ -47,8 +47,8 @@ class CrossServiceHealthCheckTest extends TestCase
         $check = new CrossServiceHealthCheck($client, $request);
 
         $this->assertTrue($check->status()->isProblem());
-        $this->assertEquals(1, count($container));
-        $this->assertEquals('http://api.example.com/health', (string) $container[0]['request']->getUri());
+        $this->assertSame(1, count($container));
+        $this->assertSame('http://api.example.com/health', (string) $container[0]['request']->getUri());
         $this->assertTrue(isset($container[0]['request']->getHeaders()['X-Service-Check']));
     }
 
@@ -67,8 +67,8 @@ class CrossServiceHealthCheckTest extends TestCase
         $check = new CrossServiceHealthCheck($client, $request);
 
         $this->assertTrue($check->status()->isOkay());
-        $this->assertEquals('Skipped, X-Service-Check header is present', $check->status()->context());
-        $this->assertEquals(0, count($container));
+        $this->assertSame('Skipped, X-Service-Check header is present', $check->status()->context());
+        $this->assertSame(0, count($container));
     }
 
     private function mockClient($responses, &$container)

--- a/tests/Checks/DatabaseHealthCheckTest.php
+++ b/tests/Checks/DatabaseHealthCheckTest.php
@@ -65,7 +65,7 @@ class DatabaseHealthCheckTest extends TestCase
         $status = (new DatabaseHealthCheck($db))->status();
 
         $this->assertTrue($status->isProblem());
-        $this->assertEquals('bad', $status->context()['connection']);
+        $this->assertSame('bad', $status->context()['connection']);
     }
 }
 

--- a/tests/Controllers/HealthCheckControllerTest.php
+++ b/tests/Controllers/HealthCheckControllerTest.php
@@ -21,7 +21,7 @@ class HealthCheckControllerTest extends TestCase
         $this->setChecks([AlwaysUpCheck::class]);
         $response = (new HealthCheckController)->__invoke($this->app);
 
-        $this->assertEquals([
+        $this->assertSame([
             'status' => 'OK',
             'always-up' => ['status' => 'OK'],
         ], json_decode($response->getContent(), true));
@@ -35,7 +35,7 @@ class HealthCheckControllerTest extends TestCase
         $this->setChecks([AlwaysUpCheck::class, AlwaysDownCheck::class]);
         $response = (new HealthCheckController)->__invoke($this->app);
 
-        $this->assertEquals([
+        $this->assertSame([
             'status' => 'PROBLEM',
             'always-up' => ['status' => 'OK'],
             'always-down' => [

--- a/tests/Controllers/PingControllerTest.php
+++ b/tests/Controllers/PingControllerTest.php
@@ -12,6 +12,6 @@ class PingControllerTest extends TestCase
      */
     public function returns_pong()
     {
-        $this->assertEquals('pong', (new PingController)->__invoke());
+        $this->assertSame('pong', (new PingController)->__invoke());
     }
 }

--- a/tests/Facades/HealthCheckTest.php
+++ b/tests/Facades/HealthCheckTest.php
@@ -16,6 +16,6 @@ class HealthCheckTest extends TestCase
         $this->app->register(HealthCheckServiceProvider::class);
 
         config(['healthcheck.checks' => [\UKFast\HealthCheck\Checks\EnvHealthCheck::class]]);
-        $this->assertEquals(1, HealthCheck::all()->count());
+        $this->assertSame(1, HealthCheck::all()->count());
     }
 }

--- a/tests/HealthCheckServiceProviderTest.php
+++ b/tests/HealthCheckServiceProviderTest.php
@@ -27,7 +27,7 @@ class HealthCheckServiceProviderTest extends TestCase
         config(['healthcheck.checks' => []]);
 
         $response = $this->get('/health');
-        $this->assertEquals('{"status":"OK"}', $response->getContent());
+        $this->assertSame('{"status":"OK"}', $response->getContent());
     }
 
     /**
@@ -40,7 +40,7 @@ class HealthCheckServiceProviderTest extends TestCase
         config(['healthcheck.checks' => []]);
 
         $response = $this->get('/ping');
-        $this->assertEquals('pong', $response->getContent());
+        $this->assertSame('pong', $response->getContent());
     }
 
     /**

--- a/tests/Middleware/AddHeadersTest.php
+++ b/tests/Middleware/AddHeadersTest.php
@@ -27,8 +27,8 @@ class AddHeadersTest extends TestCase
             return response()->json(null, 500);
         });
 
-        $this->assertEquals(1, $response->headers->get('X-always-up-status'));
-        $this->assertEquals(0, $response->headers->get('X-always-down-status'));
+        $this->assertSame('1', $response->headers->get('X-always-up-status'));
+        $this->assertSame('0', $response->headers->get('X-always-down-status'));
     }
 }
 

--- a/tests/Middleware/BasicAuthTest.php
+++ b/tests/Middleware/BasicAuthTest.php
@@ -27,8 +27,8 @@ class BasicAuthTest extends TestCase
             return response('body', 500);
         });
 
-        $this->assertEquals('', $response->getContent());
-        $this->assertEquals(500, $response->status());
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(500, $response->status());
     }
 
     /**
@@ -47,8 +47,8 @@ class BasicAuthTest extends TestCase
             return response('body', 500);
         });
 
-        $this->assertEquals('', $response->getContent());
-        $this->assertEquals(500, $response->status());
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(500, $response->status());
     }
 
     /**
@@ -70,7 +70,7 @@ class BasicAuthTest extends TestCase
             return response('body', 500);
         });
 
-        $this->assertEquals('body', $response->getContent());
-        $this->assertEquals(500, $response->status());
+        $this->assertSame('body', $response->getContent());
+        $this->assertSame(500, $response->status());
     }
 }

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -35,7 +35,7 @@ class StatusTest extends TestCase
     {
         $status = (new Status)->withContext('arbitrary context');
 
-        $this->assertEquals('arbitrary context', $status->context());
+        $this->assertSame('arbitrary context', $status->context());
     }
 
     /**
@@ -45,7 +45,7 @@ class StatusTest extends TestCase
     {
         $status = (new Status)->withName('redis');
 
-        $this->assertEquals('redis', $status->name());
+        $this->assertSame('redis', $status->name());
     }
 
     /**
@@ -55,6 +55,6 @@ class StatusTest extends TestCase
     {
         $status = (new Status)->problem('My thing doesnt work');
 
-        $this->assertEquals('My thing doesnt work', $status->message());
+        $this->assertSame('My thing doesnt work', $status->message());
     }
 }


### PR DESCRIPTION
AssertSame reports an error if the two elements do not share type and value.
For example: this code $this->assertEquals(3, true); give uns true :-////
Please use assertSame, not assertEquals