### PR TITLE
Increase Test coverage for CacheHealthCheck

### DIFF
--- a/tests/Checks/CacheHealthCheckTest.php
+++ b/tests/Checks/CacheHealthCheckTest.php
@@ -35,6 +35,26 @@ class CacheHealthCheckTest extends TestCase
     /**
      * @test
      */
+    public function shows_problem_if_incorrect_read_from_cache()
+    {
+        config([
+            'healthcheck.cache.stores' => [
+                'local'
+            ]
+        ]);
+
+        Cache::shouldReceive('store')->with('local')->once()->andReturnSelf()
+            ->shouldReceive('put')->once()
+            ->shouldReceive('pull')->once()->andReturn('incorrect-string');
+
+        $status = (new CacheHealthCheck($this->app))->status();
+
+        $this->assertTrue($status->isProblem());
+    }
+
+    /**
+     * @test
+     */
     public function shows_okay_if_can_write_to_cache()
     {
         config([


### PR DESCRIPTION
This adds a test to cover the case where the incorrect value is received from Cache and brings coverage of CacheHealthCheck to 100%