### PR TITLE
Add HEALTH_CHECK_CHECKS to pass checks names as env value

### DIFF
--- a/config/healthcheck.php
+++ b/config/healthcheck.php
@@ -7,14 +7,15 @@ return [
     'base-path' => '',
 
     /**
-     * List of health checks to run when determining the health
-     * of the service
+     * Comma separated list of health checks to run when determining the health
+     * of the service.
+     * Class path or bind name(alias should be bind with "hc_" prefix, for example - "hc_cache")
      */
-    'checks' => [
-        UKFast\HealthCheck\Checks\LogHealthCheck::class,
-        UKFast\HealthCheck\Checks\DatabaseHealthCheck::class,
-        UKFast\HealthCheck\Checks\EnvHealthCheck::class
-    ],
+    'checks' => env('HEALTH_CHECK_CHECKS', implode(',', [
+        UKFast\HealthCheck\Checks\LogHealthCheck::NAME,
+        UKFast\HealthCheck\Checks\DatabaseHealthCheck::NAME,
+        UKFast\HealthCheck\Checks\EnvHealthCheck::class,
+    ])),
 
     /**
      * A list of middleware to run on the health-check route

--- a/src/Checks/CacheHealthCheck.php
+++ b/src/Checks/CacheHealthCheck.php
@@ -7,7 +7,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class CacheHealthCheck extends HealthCheck
 {
-    protected $name = 'cache';
+    const NAME = 'cache';
+
+    protected $name = self::NAME;
 
     protected $workingStores = [];
     

--- a/src/Checks/CrossServiceHealthCheck.php
+++ b/src/Checks/CrossServiceHealthCheck.php
@@ -9,7 +9,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class CrossServiceHealthCheck extends HealthCheck
 {
-    protected $name = 'x-service-checks';
+    const NAME = 'x-service-checks';
+
+    protected $name = self::NAME;
 
     /**
      * @var \GuzzleHttp\Client

--- a/src/Checks/DatabaseHealthCheck.php
+++ b/src/Checks/DatabaseHealthCheck.php
@@ -8,7 +8,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class DatabaseHealthCheck extends HealthCheck
 {
-    protected $name = 'database';
+    const NAME = 'database';
+
+    protected $name = self::NAME;
 
     /** @var \Illuminate\Database\DatabaseManager */
     protected $db;

--- a/src/Checks/EnvHealthCheck.php
+++ b/src/Checks/EnvHealthCheck.php
@@ -6,7 +6,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class EnvHealthCheck extends HealthCheck
 {
-    protected $name = 'env';
+    const NAME = 'env';
+
+    protected $name = self::NAME;
     
     public function status()
     {

--- a/src/Checks/HttpHealthCheck.php
+++ b/src/Checks/HttpHealthCheck.php
@@ -10,7 +10,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class HttpHealthCheck extends HealthCheck
 {
-    protected $name = 'http';
+    const NAME = 'http';
+
+    protected $name = self::NAME;
 
     public function status()
     {

--- a/src/Checks/LogHealthCheck.php
+++ b/src/Checks/LogHealthCheck.php
@@ -8,7 +8,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class LogHealthCheck extends HealthCheck
 {
-    protected $name = 'log';
+    const NAME = 'log';
+
+    protected $name = self::NAME;
 
     protected $logger;
 

--- a/src/Checks/MigrationUpToDateHealthCheck.php
+++ b/src/Checks/MigrationUpToDateHealthCheck.php
@@ -8,7 +8,9 @@ use UKFast\HealthCheck\Status;
 
 class MigrationUpToDateHealthCheck extends HealthCheck
 {
-    protected $name = 'migration';
+    const NAME = 'migration';
+
+    protected $name = self::NAME;
 
     /**
      * @var Migrator

--- a/src/Checks/PackageSecurityHealthCheck.php
+++ b/src/Checks/PackageSecurityHealthCheck.php
@@ -8,7 +8,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class PackageSecurityHealthCheck extends HealthCheck
 {
-    protected $name = 'package-security';
+    const NAME = 'package-security';
+
+    protected $name = self::NAME;
 
     protected $vulnerablePackages = [];
 

--- a/src/Checks/RedisHealthCheck.php
+++ b/src/Checks/RedisHealthCheck.php
@@ -8,7 +8,9 @@ use Exception;
 
 class RedisHealthCheck extends HealthCheck
 {
-    protected $name = 'redis';
+    const NAME = 'redis';
+
+    protected $name = self::NAME;
 
     public function status()
     {

--- a/src/Checks/SchedulerHealthCheck.php
+++ b/src/Checks/SchedulerHealthCheck.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Facades\Cache;
 
 class SchedulerHealthCheck extends HealthCheck
 {
-    protected $name = 'scheduler';
+    const NAME = 'scheduler';
+
+    protected $name = self::NAME;
     
     public function status()
     {

--- a/src/Checks/StorageHealthCheck.php
+++ b/src/Checks/StorageHealthCheck.php
@@ -8,7 +8,9 @@ use UKFast\HealthCheck\HealthCheck;
 
 class StorageHealthCheck extends HealthCheck
 {
-    protected $name = 'storage';
+    const NAME = 'storage';
+
+    protected $name = self::NAME;
 
     protected $workingDisks = [];
     

--- a/src/HealthCheckServiceProvider.php
+++ b/src/HealthCheckServiceProvider.php
@@ -3,35 +3,38 @@
 namespace UKFast\HealthCheck;
 
 use Illuminate\Support\ServiceProvider;
+use UKFast\HealthCheck\Checks\CacheHealthCheck;
+use UKFast\HealthCheck\Checks\CrossServiceHealthCheck;
+use UKFast\HealthCheck\Checks\DatabaseHealthCheck;
+use UKFast\HealthCheck\Checks\EnvHealthCheck;
+use UKFast\HealthCheck\Checks\HttpHealthCheck;
+use UKFast\HealthCheck\Checks\LogHealthCheck;
+use UKFast\HealthCheck\Checks\MigrationUpToDateHealthCheck;
+use UKFast\HealthCheck\Checks\PackageSecurityHealthCheck;
+use UKFast\HealthCheck\Checks\RedisHealthCheck;
+use UKFast\HealthCheck\Checks\SchedulerHealthCheck;
+use UKFast\HealthCheck\Checks\StorageHealthCheck;
 use UKFast\HealthCheck\Commands\CacheSchedulerRunning;
 use UKFast\HealthCheck\Controllers\PingController;
 use UKFast\HealthCheck\Controllers\HealthCheckController;
 
 class HealthCheckServiceProvider extends ServiceProvider
 {
+    const CHECK_BIND_PREFIX = 'hc_';
+
     public function boot()
     {
         $this->configure();
-        $this->app->make('router')->get($this->withBasePath('/health'), [
-            'middleware' => config('healthcheck.middleware'),
-            'uses' => HealthCheckController::class
-        ]);
-
-        $this->app->bind('app-health', function ($app) {
-            $checks = collect();
-            foreach ($app->config->get('healthcheck.checks') as $classPath) {
-                $checks->push($app->make($classPath));
-            }
-            return new AppHealth($checks);
-        });
+        $this->registerHealthCheckRoute();
+        $this->registerPingRoute();
+        $this->bindChecks();
+        $this->appHealthSetup();
 
         if ($this->app->runningInConsole()) {
             $this->commands([
                 CacheSchedulerRunning::class,
             ]);
         }
-
-        $this->app->make('router')->get($this->withBasePath('/ping'), PingController::class);
     }
 
     protected function configure()
@@ -57,5 +60,62 @@ class HealthCheckServiceProvider extends ServiceProvider
         }
 
         return "/$basePath/$path";
+    }
+
+    private function registerHealthCheckRoute()
+    {
+        $this->app->make('router')->get($this->withBasePath('/health'), [
+            'middleware' => config('healthcheck.middleware'),
+            'uses' => HealthCheckController::class,
+        ]);
+    }
+
+    private function registerPingRoute()
+    {
+        $this->app->make('router')->get($this->withBasePath('/ping'), PingController::class);
+    }
+
+    private function bindChecks()
+    {
+        $checks = [
+            CacheHealthCheck::NAME => CacheHealthCheck::class,
+            CrossServiceHealthCheck::NAME => CrossServiceHealthCheck::class,
+            DatabaseHealthCheck::NAME => DatabaseHealthCheck::class,
+            EnvHealthCheck::NAME => EnvHealthCheck::class,
+            HttpHealthCheck::NAME => HttpHealthCheck::class,
+            LogHealthCheck::NAME => LogHealthCheck::class,
+            MigrationUpToDateHealthCheck::NAME => MigrationUpToDateHealthCheck::class,
+            PackageSecurityHealthCheck::NAME => PackageSecurityHealthCheck::class,
+            RedisHealthCheck::NAME => RedisHealthCheck::class,
+            SchedulerHealthCheck::NAME => SchedulerHealthCheck::class,
+            StorageHealthCheck::NAME => StorageHealthCheck::class,
+        ];
+
+        /** @var HealthCheck $checkClass */
+        foreach ($checks as $name => $checkClass)
+        {
+            $alias = self::CHECK_BIND_PREFIX . $name;
+            $this->app->bind($alias, $checkClass);
+        }
+    }
+
+    private function appHealthSetup()
+    {
+        $this->app->bind('app-health', function ($app) {
+            $checks = collect();
+            $checkNames = $app->config->get('healthcheck.checks');
+            if (!is_array($checkNames)) {
+                $checkNames = explode(',', $checkNames);
+            }
+            foreach ($checkNames as $checkName) {
+                if (!class_exists($checkName)) {
+                    //bind alias
+                    $checkName = self::CHECK_BIND_PREFIX . $checkName;
+                }
+
+                $checks->push($app->make($checkName));
+            }
+            return new AppHealth($checks);
+        });
     }
 }

--- a/tests/HealthCheckServiceProviderTest.php
+++ b/tests/HealthCheckServiceProviderTest.php
@@ -4,6 +4,9 @@ namespace Tests;
 
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use UKFast\HealthCheck\AppHealth;
+use UKFast\HealthCheck\Checks\CacheHealthCheck;
+use UKFast\HealthCheck\Checks\EnvHealthCheck;
 use UKFast\HealthCheck\Checks\LogHealthCheck;
 use UKFast\HealthCheck\HealthCheckServiceProvider;
 use UKFast\HealthCheck\Commands\UpdateSchedulerTimestamp;
@@ -64,9 +67,12 @@ class HealthCheckServiceProviderTest extends TestCase
     {
         $this->app->register(HealthCheckServiceProvider::class);
 
-        config(['healthcheck.checks' => [\UKFast\HealthCheck\Checks\EnvHealthCheck::class]]);
+        config(['healthcheck.checks' => [EnvHealthCheck::class, CacheHealthCheck::NAME]]);
+        /** @var AppHealth $appHealth */
+        $appHealth = $this->app->make('app-health');
 
-        $this->assertInstanceOf(\UKFast\HealthCheck\AppHealth::class, $this->app->make('app-health'));
+        $this->assertInstanceOf(AppHealth::class, $appHealth);
+        $this->assertCount(2, $appHealth->all());
     }
 
     /**


### PR DESCRIPTION
Add `HEALTH_CHECK_CHECKS` env to have ability to pass checks names as env value, for example:
```dotenv
HEALTH_CHECK_CHECKS=log,redis,database
```

Check name should be bound to class with prefix `hc_` to avoid collision, for example:
```php
//ServiceProvider.php
$this->app->bind('hc_log', LogHealthCheck::class);
$this->app->bind('hc_redis', RedisHealthCheck::class);
$this->app->bind('hc_database', DatabaseHealthCheck::class);
```

p.s. it's fully backward compatible