### PR TITLE
Fix Lumen named route bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix named route bug in Lumen.
 
 ## [1.9.0] - 2021-02-12
 

--- a/src/HealthCheckServiceProvider.php
+++ b/src/HealthCheckServiceProvider.php
@@ -16,7 +16,8 @@ class HealthCheckServiceProvider extends ServiceProvider
         $this->app->make('router')->get($this->withBasePath('/health'), [
             'middleware' => config('healthcheck.middleware'),
             'uses' => HealthCheckController::class,
-        ])->name(config('healthcheck.route-name'));
+            'as' => config('healthcheck.route-name')
+        ]);
 
         $this->app->bind('app-health', function ($app) {
             $checks = collect();


### PR DESCRIPTION
After tagging `v1.9.0` we've found a bug which prevents `/health` from working due to `Router::name()` being undefined.

I've fixed it in this MR and tested in Laravel 5.4 and Lumen 7.