### PR TITLE
Allow overriding health and ping route paths

### DIFF
--- a/config/healthcheck.php
+++ b/config/healthcheck.php
@@ -6,6 +6,14 @@ return [
      */
     'base-path' => '',
 
+    /**
+     * Path to host the health check
+     */
+    'route-paths' => [
+        'health' => '/health',
+        'ping' => '/ping',
+    ],
+
     /*
      * List of health checks to run when determining the health
      * of the service

--- a/config/healthcheck.php
+++ b/config/healthcheck.php
@@ -7,7 +7,7 @@ return [
     'base-path' => '',
 
     /**
-     * Path to host the health check
+     * Paths to host the health check and ping endpoints
      */
     'route-paths' => [
         'health' => '/health',

--- a/src/HealthCheckServiceProvider.php
+++ b/src/HealthCheckServiceProvider.php
@@ -14,7 +14,7 @@ class HealthCheckServiceProvider extends ServiceProvider
     {
         $this->configure();
 
-        $this->app->make('router')->get($this->withBasePath('/health'), [
+        $this->app->make('router')->get($this->withBasePath(config('healthcheck.route-paths.health')), [
             'middleware' => config('healthcheck.middleware'),
             'uses' => HealthCheckController::class,
             'as' => config('healthcheck.route-name')
@@ -36,7 +36,7 @@ class HealthCheckServiceProvider extends ServiceProvider
             ]);
         }
 
-        $this->app->make('router')->get($this->withBasePath('/ping'), PingController::class);
+        $this->app->make('router')->get($this->withBasePath(config('healthcheck.route-paths.ping')), PingController::class);
     }
 
     protected function configure()

--- a/tests/Controllers/HealthCheckControllerTest.php
+++ b/tests/Controllers/HealthCheckControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Controllers;
 use Tests\TestCase;
 use UKFast\HealthCheck\Controllers\HealthCheckController;
 use UKFast\HealthCheck\HealthCheck;
+use UKFast\HealthCheck\HealthCheckServiceProvider;
 
 class HealthCheckControllerTest extends TestCase
 {
@@ -20,6 +21,28 @@ class HealthCheckControllerTest extends TestCase
     {
         $this->setChecks([AlwaysUpCheck::class]);
         $response = (new HealthCheckController)->__invoke($this->app);
+
+        $this->assertSame([
+            'status' => 'OK',
+            'always-up' => ['status' => 'OK'],
+        ], json_decode($response->getContent(), true));
+    }
+
+    /**
+     * @test
+     */
+    public function overrides_default_path()
+    {
+        config([
+            'healthcheck.route-paths.health' => '/healthz',
+        ]);
+
+        // Manually re-boot the service provider to override the path
+        $this->app->getProvider(HealthCheckServiceProvider::class)->boot();
+
+        $this->setChecks([AlwaysUpCheck::class]);
+
+        $response = $this->get('/healthz');
 
         $this->assertSame([
             'status' => 'OK',

--- a/tests/Controllers/PingControllerTest.php
+++ b/tests/Controllers/PingControllerTest.php
@@ -4,14 +4,37 @@ namespace Tests\Controllers;
 
 use Tests\TestCase;
 use UKFast\HealthCheck\Controllers\PingController;
+use UKFast\HealthCheck\HealthCheckServiceProvider;
 
 class PingControllerTest extends TestCase
 {
+    public function getPackageProviders($app)
+    {
+        return ['UKFast\HealthCheck\HealthCheckServiceProvider'];
+    }
+
     /**
      * @test
      */
     public function returns_pong()
     {
         $this->assertSame('pong', (new PingController)->__invoke());
+    }
+
+    /**
+     * @test
+     */
+    public function overrides_default_path()
+    {
+        config([
+            'healthcheck.route-paths.ping' => '/pingz',
+        ]);
+
+        // Manually re-boot the service provider to override the path
+        $this->app->getProvider(HealthCheckServiceProvider::class)->boot();
+
+        $response = $this->get('/pingz');
+
+        $this->assertSame('pong', $response->getContent());
     }
 }


### PR DESCRIPTION
In my use case, we would like to use the`/healthz` path commonly used in the Kubernetes and Docker ecosystem. This change should allow us to override this path without affecting existing default functionality for the non-z paths.