### PR TITLE
Fix Backwards Incompatible Config Additions

### DIFF
--- a/src/HealthCheckServiceProvider.php
+++ b/src/HealthCheckServiceProvider.php
@@ -14,7 +14,7 @@ class HealthCheckServiceProvider extends ServiceProvider
     {
         $this->configure();
 
-        $this->app->make('router')->get($this->withBasePath(config('healthcheck.route-paths.health')), [
+        $this->app->make('router')->get($this->withBasePath(config('healthcheck.route-paths.health', '/health')), [
             'middleware' => config('healthcheck.middleware'),
             'uses' => HealthCheckController::class,
             'as' => config('healthcheck.route-name')
@@ -36,13 +36,14 @@ class HealthCheckServiceProvider extends ServiceProvider
             ]);
         }
 
-        $this->app->make('router')->get($this->withBasePath(config('healthcheck.route-paths.ping')), PingController::class);
+        $this->app->make('router')->get($this->withBasePath(config('healthcheck.route-paths.ping', '/ping')), PingController::class);
     }
 
     protected function configure()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/healthcheck.php', 'healthcheck');
         $configPath = $this->app->basePath().'/config/healthcheck.php';
+
         $this->publishes([
             __DIR__.'/../config/healthcheck.php' => $configPath,
         ], 'config');

--- a/tests/Controllers/HealthCheckControllerTest.php
+++ b/tests/Controllers/HealthCheckControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Controllers;
 
 use Illuminate\Http\Response;
+use Illuminate\Routing\RouteCollection;
 use Tests\TestCase;
 use UKFast\HealthCheck\Controllers\HealthCheckController;
 use UKFast\HealthCheck\HealthCheck;
@@ -34,6 +35,14 @@ class HealthCheckControllerTest extends TestCase
      */
     public function overrides_default_ping_path()
     {
+        app('router')->setRoutes(app(RouteCollection::class));
+
+        $response = $this->get('/ping');
+        $response->assertStatus(404);
+
+        $response = $this->get('/pingz');
+        $response->assertStatus(404);
+
         config([
             'healthcheck.route-paths.ping' => '/pingz',
         ]);
@@ -44,8 +53,10 @@ class HealthCheckControllerTest extends TestCase
         $this->setChecks([AlwaysUpCheck::class]);
 
         $response = $this->get('/pingz');
-
         $this->assertSame('pong', $response->getContent());
+
+        $response = $this->get('/ping');
+        $response->assertStatus(404);
     }
 
     /**
@@ -53,6 +64,14 @@ class HealthCheckControllerTest extends TestCase
      */
     public function overrides_default_health_path()
     {
+        app('router')->setRoutes(app(RouteCollection::class));
+
+        $response = $this->get('/health');
+        $response->assertStatus(404);
+
+        $response = $this->get('/healthz');
+        $response->assertStatus(404);
+
         config([
             'healthcheck.route-paths.health' => '/healthz',
         ]);
@@ -63,6 +82,15 @@ class HealthCheckControllerTest extends TestCase
         $this->setChecks([AlwaysUpCheck::class]);
 
         $response = $this->get('/healthz');
+        $this->assertSame([
+            'status' => 'OK',
+            'always-up' => ['status' => 'OK'],
+        ], json_decode($response->getContent(), true));
+
+        $response = $this->get('/health');
+        $response->assertStatus(404);
+    }
+
 
         $this->assertSame([
             'status' => 'OK',

--- a/tests/Controllers/HealthCheckControllerTest.php
+++ b/tests/Controllers/HealthCheckControllerTest.php
@@ -91,6 +91,49 @@ class HealthCheckControllerTest extends TestCase
         $response->assertStatus(404);
     }
 
+    /**
+     * @test
+     */
+    public function defaults_the_ping_path_if_config_is_not_set()
+    {
+        app('router')->setRoutes(app(RouteCollection::class));
+
+        $response = $this->get('/ping');
+        $response->assertStatus(404);
+
+        config([
+            'healthcheck.route-paths' => null,
+        ]);
+
+        // Manually re-boot the service provider to override the path
+        $this->app->getProvider(HealthCheckServiceProvider::class)->boot();
+
+        $this->setChecks([AlwaysUpCheck::class]);
+
+        $response = $this->get('/ping');
+        $this->assertSame('pong', $response->getContent());
+
+    }
+
+    /**
+     * @test
+     */
+    public function defaults_the_health_path_if_config_is_not_set()
+    {
+        config([
+            'healthcheck.route-paths' => null,
+        ]);
+
+        app('router')->setRoutes(app(RouteCollection::class));
+
+        $response = $this->get('/health');
+
+
+        $this->app->getProvider(HealthCheckServiceProvider::class)->boot();
+
+        $this->setChecks([AlwaysUpCheck::class]);
+
+        $response = $this->get('/health');
 
         $this->assertSame([
             'status' => 'OK',

--- a/tests/Controllers/HealthCheckControllerTest.php
+++ b/tests/Controllers/HealthCheckControllerTest.php
@@ -32,7 +32,29 @@ class HealthCheckControllerTest extends TestCase
     /**
      * @test
      */
-    public function overrides_default_path()
+    public function overrides_default_ping_path()
+    {
+        config([
+            'healthcheck.route-paths.health' => '/pingz',
+        ]);
+
+        // Manually re-boot the service provider to override the path
+        $this->app->getProvider(HealthCheckServiceProvider::class)->boot();
+
+        $this->setChecks([AlwaysUpCheck::class]);
+
+        $response = $this->get('/pingz');
+
+        $this->assertSame([
+            'status' => 'OK',
+            'always-up' => ['status' => 'OK'],
+        ], json_decode($response->getContent(), true));
+    }
+
+    /**
+     * @test
+     */
+    public function overrides_default_health_path()
     {
         config([
             'healthcheck.route-paths.health' => '/healthz',

--- a/tests/Controllers/HealthCheckControllerTest.php
+++ b/tests/Controllers/HealthCheckControllerTest.php
@@ -35,7 +35,7 @@ class HealthCheckControllerTest extends TestCase
     public function overrides_default_ping_path()
     {
         config([
-            'healthcheck.route-paths.health' => '/pingz',
+            'healthcheck.route-paths.ping' => '/pingz',
         ]);
 
         // Manually re-boot the service provider to override the path
@@ -45,10 +45,7 @@ class HealthCheckControllerTest extends TestCase
 
         $response = $this->get('/pingz');
 
-        $this->assertSame([
-            'status' => 'OK',
-            'always-up' => ['status' => 'OK'],
-        ], json_decode($response->getContent(), true));
+        $this->assertSame('pong', $response->getContent());
     }
 
     /**


### PR DESCRIPTION
A backwards incompatible change was spotted which defaulted the `/ping` & `/health` routes for existing uses of the package using existing config to both listen on `/`.

This adds a fallback so if the config doesn't exist it defaults to  `/ping` & `/health`.

Alongside this, I've added a test for the `/ping` customization and tweaked the `/health` customisation test as this still had the default `/health` route due to how orchestra bootstraps Laravel.