### PR TITLE
fix(check): env check false positive when value is defined but null

### DIFF
--- a/config/healthcheck.php
+++ b/config/healthcheck.php
@@ -120,6 +120,13 @@ return [
     ],
 
     /*
+     * Default value for env checks.
+     * For each key, the check will call `env(KEY, config('healthcheck.env-default-key'))` 
+     * to avoid false positives when `env(KEY)` is defined but is null.
+     */
+    'env-check-key' => 'HEALTH_CHECK_ENV_DEFAULT_VALUE',
+
+    /*
      * Additional config can be put here. For example, a health check
      * for your .env file needs to know which keys need to be present.
      * You can pass this information by specifying a new key here then

--- a/src/Checks/EnvHealthCheck.php
+++ b/src/Checks/EnvHealthCheck.php
@@ -10,8 +10,10 @@ class EnvHealthCheck extends HealthCheck
     
     public function status()
     {
+        $default = config('healthcheck.env-check-key', 'HEALTH_CHECK_ENV_DEFAULT_VALUE');
+
         foreach (config('healthcheck.required-env') as $env) {
-            if (env($env) === null) {
+            if (env($env, $default) === $default) {
                 $missing[] = $env;
             }
         }

--- a/tests/Checks/EnvHealthCheckTest.php
+++ b/tests/Checks/EnvHealthCheckTest.php
@@ -46,4 +46,19 @@ class EnvHealthCheckTest extends TestCase
 
         $this->assertTrue($status->isOkay());
     }
+
+    /**
+     * @test
+     */
+    public function shows_okay_if_required_env_params_is_present_but_null()
+    {
+        putenv('REDIS_PASSWORD=null');
+
+        config(['healthcheck.required-env' => [
+            'REDIS_PASSWORD',
+        ]]);
+        $status = (new EnvHealthCheck)->status();
+
+        $this->assertTrue($status->isOkay());
+    }
 }

--- a/tests/Checks/EnvHealthCheckTest.php
+++ b/tests/Checks/EnvHealthCheckTest.php
@@ -50,7 +50,7 @@ class EnvHealthCheckTest extends TestCase
     /**
      * @test
      */
-    public function shows_okay_if_required_env_params_is_present_but_null()
+    public function shows_okay_if_required_env_param_is_present_but_null()
     {
         putenv('REDIS_PASSWORD=null');
 


### PR DESCRIPTION
`UKFast\HealthCheck\Checks\EnvHealthCheck` creates false positives when an environment value is _set_ but its value is `null`.

This happens because `if (env($env) === null)` returns `true` for `null` values, as `env('MISSING_KEY')` returns `null`.  

Passing a (configurable) default value to `env()` makes it easy to check if the default value was returned (which is what we really want).