### PR TITLE
Adds 9.0 to illuminate/* dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,18 +54,18 @@
     "require": {
         "php": ">=5.6",
         "ext-json": "*",
-        "illuminate/support": "^5.4|^6.0|^7.0|^8.0",
-        "illuminate/http": "^5.4|^6.0|^7.0|^8.0",
-        "illuminate/console": "^5.4|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.4|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/http": "^5.4|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/console": "^5.4|^6.0|^7.0|^8.0|^9.0",
         "nesbot/carbon": "^1.26.3|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.0",
         "orchestra/testbench": "^3.0|^4.0|^5.0|^6.0",
         "mockery/mockery": "^1.0",
-        "illuminate/database": "^5.4|^6.0|^7.0|^8.0",
-        "illuminate/log": "^5.4|^6.0|^7.0|^8.0",
-        "illuminate/redis": "^5.4|^6.0|^7.0|^8.0",
+        "illuminate/database": "^5.4|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/log": "^5.4|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/redis": "^5.4|^6.0|^7.0|^8.0|^9.0",
         "guzzlehttp/guzzle": ">=5.6.3"
     },
     "suggest": {


### PR DESCRIPTION
I would be the first to admit I am not an advanced user of this package, but after some basic testing this package appears to be working as expected with the ^9.0 range.

Thank you!